### PR TITLE
updated export on geojson-parser.js

### DIFF
--- a/geojson-parser.js
+++ b/geojson-parser.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const geojson_helpers_1 = require("./geojson-helpers");
-class Geojson extends geojson_helpers_1.GeojsonHelpers {
+module.exports = class Geojson extends geojson_helpers_1.GeojsonHelpers {
     /**
     * @Method: Parse geometries from the json string.
     * @Param {string}
@@ -63,4 +63,3 @@ class Geojson extends geojson_helpers_1.GeojsonHelpers {
         }
     }
 }
-exports.Geojson = Geojson;


### PR DESCRIPTION
this fix allows the class to be exported per the instructions. Without this fix the library can be accessed with the following require statement.

`  var geojson = require('geojson-parser-js').Geojson `

Hope this is helpful.